### PR TITLE
Implement query action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.5
+
+- Added a new aciton `query` that can be used to execute generic SWQL queries.
+  Contributed by Nick Maludy (Encore Technologies)
+
 ## 0.7.4
 
 - Added new action `get_node_custom_properties` to retrieve custom properties set on

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+THIS_FILE := $(lastword $(MAKEFILE_LIST))
+ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+CI_REPO_PATH ?= $(ROOT_DIR)/ci
+CI_REPO_BRANCH ?= master
+ROOT_VIRTUALENV ?= ""
+
+# read in pack's name from pack.yaml, export it so that the ci/Makefile
+# can access its value
+export PACK_NAME := $(shell grep "name:" pack.yaml | awk '{ print $$2 }')
+
+.PHONY: all
+all: .DEFAULT
+
+.PHONY: clean
+clean: clean-ci-repo clean-pyc
+
+.PHONY: pack-name
+pack-name: .pack-name
+
+.PHONY: .pack-name
+.pack-name:
+	@echo $(PACK_NAME)
+
+# Clone the ci-repo into the ci/ directory
+.PHONY: clone-ci-repo
+clone-ci-repo:
+	@echo
+	@echo "==================== clone-ci-repo ===================="
+	@echo
+	@if [ ! -d "$(CI_REPO_PATH)" ]; then \
+		git clone https://github.com/EncoreTechnologies/ci-stackstorm.git --depth 1 --single-branch --branch $(CI_REPO_BRANCH) $(CI_REPO_PATH); \
+	else \
+		cd $(CI_REPO_PATH); \
+		git pull; \
+	fi;
+
+# Clean the ci-repo (calling `make clean` in that directory), then remove the
+# ci-repo directory
+.PHONY: clean-ci-repo
+clean-ci-repo:
+	@echo
+	@echo "==================== clean-ci-repo ===================="
+	@echo
+	@if [ -d "$(CI_REPO_PATH)" ]; then \
+		make -f $(ROOT_DIR)/ci/Makefile clean; \
+	fi;
+	rm -rf $(CI_REPO_PATH)
+
+# Clean *.pyc files.
+.PHONY: clean-pyc
+clean-pyc:
+	@echo
+	@echo "==================== clean-pyc ===================="
+	@echo
+	find $(ROOT_DIR) -name 'ci' -prune -or -name '.git' -or -type f -name "*.pyc" -print | xargs -r rm
+
+# list all makefile targets
+.PHONY: list
+list:
+	@if [ -d "$(CI_REPO_PATH)" ]; then \
+		$(MAKE) --no-print-directory -f $(ROOT_DIR)/ci/Makefile list; \
+	fi;
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | sort | uniq | xargs
+
+# forward all make targets not found in this makefile to the ci makefile to do
+# the actual work (by calling the invoke-ci-makefile target)
+# http://stackoverflow.org/wiki/Last-Resort_Makefile_Targets
+# Unfortunately the .DEFAULT target doesn't allow for dependencies
+# so we have to manually specify all of the steps in this target.
+.DEFAULT: 
+	$(MAKE) clone-ci-repo
+	@echo
+	@echo "==================== invoke ci/Makefile (targets: $(MAKECMDGOALS)) ===================="
+	@echo
+	ROOT_VIRTUALENV=$(ROOT_VIRTUALENV) make -f $(ROOT_DIR)/ci/Makefile $(MAKECMDGOALS)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ snmp_internal: "SNMP community to use if internal specified"
 * `node_status` - Query Solarwinds Orion for a node's status (i.e. Up/Down)
 * `node_unmanage` - Unmanage an Solarwinds Orion node
 * `nodes_pollnow` - Force muliple polls of a list of Solarwinds Orion nodes.
+* `query` - Execute generic SWQL queries.
 * `start_discovery` - Create a discovery profile in Solarwinds Orion.
 * `update_node_custom_properties` - Update an Orion Nodes custom properties
 * `update_node_poller` - Update an Orion Nodes poller

--- a/actions/query.yaml
+++ b/actions/query.yaml
@@ -1,0 +1,23 @@
+---
+description: "Query Solarwinds Orion using SWQL (SolarWinds Query language)"
+enabled: true
+entry_point: 'query_action.py'
+name: "query"
+pack: "orion"
+runner_type: "python-script"
+parameters:
+  query:
+    type: "string"
+    description: "Query string in SWQL syntax."
+    required: true
+  parameters:
+    type: "object"
+    description: >
+      For SWQL queries that are parameterized, this is a dict/object of parameters to
+      insert into the query.
+      Example:
+        query: "SELECT Uri FROM Orion.Pollers WHERE PollerID=@pollerid"
+        parameters:
+          pollerid: 9
+    required: false
+    default: {}

--- a/actions/query_action.py
+++ b/actions/query_action.py
@@ -1,0 +1,25 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lib.actions import OrionBaseAction
+
+
+class QueryAction(OrionBaseAction):
+    def run(self, query, parameters):
+        """
+        Query Solarwinds Orion.
+        """
+        self.connect()
+        return self.query(query, **parameters)

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
    - ncm
    - npm
    - monitoring
-version: 0.7.4
+version: 0.7.5
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_query.py
+++ b/tests/test_action_query.py
@@ -1,0 +1,44 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+from mock import MagicMock
+
+from orion_base_action_test_case import OrionBaseActionTestCase
+
+from query_action import QueryAction
+
+__all__ = [
+    'QueryTestCase'
+]
+
+
+class QueryTestCase(OrionBaseActionTestCase):
+    __test__ = True
+    action_cls = QueryAction
+
+    def test_query_with_params(self):
+        query = "SELECT Uri FROM Orion.Pollers WHERE PollerID=@pollerid"
+        parameters = {"pollerid": 9}
+
+        expected = {'blah': 'router1 (NodeId: 1; ip: 192.168.0.1)'}
+
+        action = self.get_action_instance(config=self.full_config)
+        action.connect = MagicMock(return_value="orion")
+        action.query = MagicMock(return_value=expected)
+
+        result = action.run(query, parameters)
+        self.assertEquals(result, expected)
+
+        action.connect.assert_called()
+        action.query.assert_called_with(query, **parameters)


### PR DESCRIPTION
Implemented a new action that allows for running generic SWQL queries against the Orion database.

This allows us to pull data / metrics from within Orion and utilize them in other systems and expose them via ChatOps.