### PR TITLE
Ability to gather agent information

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.6
+
+- Added the ability to get agent information without getting the node.
+  Contributed by Bradley Bishop (Encore Technologies)
+
 ## 0.7.5
 
 - Added a new aciton `query` that can be used to execute generic SWQL queries.

--- a/actions/agent_delete.py
+++ b/actions/agent_delete.py
@@ -24,12 +24,12 @@ class AgentDelete(OrionBaseAction):
 
         self.connect()
 
-        orion_node = self.get_node(node)
+        orion_agent = self.get_agent(node)
 
-        if not orion_node.agent:
+        if not orion_agent:
             raise ValueError("Agent not found")
 
-        orion_data = self.delete(orion_node.agent_uri)
+        orion_data = self.delete(orion_agent['Uri'])
 
         # This Delete always returns None, so check and return True
         if orion_data is None:

--- a/actions/get_agent_id.py
+++ b/actions/get_agent_id.py
@@ -24,9 +24,9 @@ class GetAgentId(OrionBaseAction):
 
         self.connect()
 
-        orion_data = self.get_node(node)
+        orion_data = self.get_agent(node)
 
-        if not orion_data.agent:
+        if not orion_data:
             raise ValueError("Agent not found")
 
-        return orion_data.agent_id
+        return orion_data['AgentID']

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -132,17 +132,17 @@ class OrionBaseAction(Action):
 
         # Since there might not always be an agent we
         # will not raise if the results do not return anything
-        if 'results' not in data_agent:
-            msg = "No results from Orion Agent: {}".format(data_agent)
+        if 'results' not in data_agent or len(data_agent['results']) == 0:
+            msg = "No Orion Agent found: {}".format(data_agent)
             self.logger.info(msg)
             return None
 
         if len(data_agent['results']) >= 2:
             self.logger.debug(
-                "Muliple Nodes match '{}' Caption: {}".format(
-                    orion_node.npm_id, data_agent))
-            raise ValueError("Muliple Nodes match '{}' Caption".format(
-                orion_node.npm_id))
+                "Muliple Agents match '{}' Caption: {}".format(
+                    query_param, data_agent))
+            raise ValueError("Muliple Agents match '{}' Caption".format(
+                query_param))
 
         return data_agent['results'][0]
 

--- a/actions/lib/utils.py
+++ b/actions/lib/utils.py
@@ -94,7 +94,9 @@ def is_ip(ip_address):
     Returns:
        bool: True if an IP address, False if not.
     """
-    if "." in ip_address:
+    if isinstance(ip_address, int):
+        return False
+    elif "." in ip_address:
         family = socket.AF_INET
     elif ":" in ip_address:
         family = socket.AF_INET6

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
    - ncm
    - npm
    - monitoring
-version: 0.7.5
+version: 0.7.6
 python_versions:
     - "2"
     - "3"

--- a/tests/test_action_agent_delete.py
+++ b/tests/test_action_agent_delete.py
@@ -31,14 +31,8 @@ class AgentDeleteTestCase(OrionBaseActionTestCase):
         action = self.setup_connect_fail()
         self.assertRaises(ValueError, action.run)
 
-    def test_run_node_fail(self):
-        action = self.setup_query_blank_results()
-        self.assertRaises(ValueError,
-                          action.run,
-                          "router1")
-
     def test_run_agent_fail(self):
-        action = self.setup_node_exists()
+        action = self.setup_query_blank_results()
         self.assertRaises(ValueError,
                         action.run,
                         "router1")

--- a/tests/test_action_get_agent_id.py
+++ b/tests/test_action_get_agent_id.py
@@ -31,14 +31,8 @@ class GetAgentIdTestCase(OrionBaseActionTestCase):
         action = self.setup_connect_fail()
         self.assertRaises(ValueError, action.run)
 
-    def test_run_node_fail(self):
-        action = self.setup_query_blank_results()
-        self.assertRaises(ValueError,
-                        action.run,
-                        "router1")
-
     def test_run_agent_fail(self):
-        action = self.setup_node_exists()
+        action = self.setup_query_blank_results()
         self.assertRaises(ValueError,
                         action.run,
                         "router1")


### PR DESCRIPTION
Changed the Get Agent code to its own method. Method accepts searching for an Agent by NodeID, IPAddress, or Server name. Change the Get agent_id and delete_agent actions to use the new method to get agent information. This way if a node doesn't exist but the Agent does. We will still be able to get the ID and Delete the Agent if needed.

Nodes may not exist and an Agent will if the Node was not removed properly or Solarwinds detects and agent installed but doesn't create Node information properly.