### PR TITLE
Fix get_node_id error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## 0.7.8
 
-- Fixed issue where get_node_id can return a null
+- Fixed issue where get_node_id can return a null.
+- Silenced SSL warnings.
   Contributed by Bradley Bishop (Encore Technologies)
 
 ## 0.7.7

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.8
+
+- Fixed issue where get_node_id can return a null
+  Contributed by Bradley Bishop (Encore Technologies)
+
 ## 0.7.7
 
 - Added badges to README and fixed unit tests.

--- a/actions/get_node_id.py
+++ b/actions/get_node_id.py
@@ -26,7 +26,6 @@ class GetNodeId(OrionBaseAction):
 
         orion_data = self.get_node(node)
         if not orion_data.npm_id:
-            raise ValueError("No Nodes match '{}'".format(
-                node))
+            return (False, "No Nodes match '{}'".format(node))
 
         return orion_data.npm_id

--- a/actions/get_node_id.py
+++ b/actions/get_node_id.py
@@ -25,5 +25,8 @@ class GetNodeId(OrionBaseAction):
         self.connect()
 
         orion_data = self.get_node(node)
+        if not orion_data.npm_id:
+            raise ValueError("No Nodes match '{}'".format(
+                node))
 
         return orion_data.npm_id

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -21,6 +21,10 @@ from orionsdk import SwisClient
 from lib.node import OrionNode
 from lib.utils import send_user_error, is_ip
 
+# Silence ssl warnings
+import requests
+requests.packages.urllib3.disable_warnings()  # pylint: disable=no-member
+
 
 class OrionBaseAction(Action):
     def __init__(self, config):

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
    - ncm
    - npm
    - monitoring
-version: 0.7.7
+version: 0.7.8
 python_versions:
     - "2"
     - "3"

--- a/tests/test_action_get_node_id.py
+++ b/tests/test_action_get_node_id.py
@@ -30,3 +30,9 @@ class GetNodeIdTestCase(OrionBaseActionTestCase):
     def test_run_connect_fail(self):
         action = self.setup_connect_fail()
         self.assertRaises(ValueError, action.run)
+
+    def test_run_get_node_fail(self):
+        action = self.setup_query_blank_results()
+        self.assertRaises(ValueError,
+                        action.run,
+                        "router1")

--- a/tests/test_action_get_node_id.py
+++ b/tests/test_action_get_node_id.py
@@ -32,7 +32,7 @@ class GetNodeIdTestCase(OrionBaseActionTestCase):
         self.assertRaises(ValueError, action.run)
 
     def test_run_get_node_fail(self):
+        expected_return = (False, "No Nodes match 'router1'")
         action = self.setup_query_blank_results()
-        self.assertRaises(ValueError,
-                        action.run,
-                        "router1")
+        result = action.run("router1")
+        self.assertEqual(result, expected_return)


### PR DESCRIPTION
When getting node id for a node that didn't exist a null is returned. Added a raise for the case and added a test for the behavior.
before:
```
st2 run orion.get_node_id node="no_node"
.
id: 5c3f726132a49789486f61a7
status: succeeded
parameters: 
  node: no_node
result: 
  exit_code: 0
  result: null
  stderr: "/opt/stackstorm/st2/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
"
  stdout: ''
```

after:
```
st2 run orion.get_node_id node="no_node"
.
id: 5c3f817032a49789486f61b3
status: failed
parameters: 
  node: no_node
result: 
  exit_code: 0
  result: No Nodes match 'no_node'
  stderr: ''
  stdout: ''
```