### PR TITLE
Enhanced SNMPv3 Add Node and Added custom poller action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+/.idea/.gitignore

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,17 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="4">
+            <item index="0" class="java.lang.String" itemvalue="lxml" />
+            <item index="1" class="java.lang.String" itemvalue="sagenet-lib" />
+            <item index="2" class="java.lang.String" itemvalue="sagelib-FMG" />
+            <item index="3" class="java.lang.String" itemvalue="xmlrpc.client" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/stackstorm-orion.iml" filepath="$PROJECT_DIR$/.idea/stackstorm-orion.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/stackstorm-orion.iml
+++ b/.idea/stackstorm-orion.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 - Added Action 
   
-  - add_custom_poller_to_node
+- add_custom_poller_to_node
   
 - Updated node_create_snmpv3 action to include the option to specify which default pollers to enable when adding the Node
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 - Added Action 
   
-- add_custom_poller_to_node
+  - add_custom_poller_to_node
   
 - Updated node_create_snmpv3 action to include the option to specify which default pollers to enable when adding the Node
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Added Action 
   
   - add_custom_poller_to_node
+  
+- Updated node_create_snmpv3 action to include the option to specify which default pollers to enable when adding the Node
 
 ## 1.0.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.2
+-Added Action
+ add_custom_pollers_to_node
+
+
 ## 1.0.1
 
 - Corrected numerous typos and inaccurate descriptions in the code

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.3
+
+- Added Action 
+  
+  - add_custom_poller_to_node
+
 ## 1.0.2
 
 - Fixed small linting error and pushing a new version.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ snmp_internal: "SNMP community to use if internal specified"
 
 ## Actions
 
+* `add_custom_pollers_to_node` - Add a list of custom (Universal Device) pollers to a Node
 * `add_node_to_ncm` - Add an Orion Node to NCM
 * `drain_poller` - Drain nodes from one Orion poller to another.
 * `get_discovery_progress` - Get the progress of an SolarWinds Orion Discovery.
@@ -44,18 +45,18 @@ snmp_internal: "SNMP community to use if internal specified"
 * `list_sdk_verbs` - List all the verbs that can be invoked via SolarWinds Orion
 * `ncm_config_download` - Download config(s) from SolarWinds NCM Orion module.
 * `ncm_execute_script` - Execute an script on an Orion NCM Node.
-* `node_create` - Create an node in SolarWinds Orion.
-* `node_create_snmpv3` - Create an node in SolarWinds Orion with SNMPv3.
+* `node_create` - Create a node in SolarWinds Orion.
+* `node_create_snmpv3` - Create a node in SolarWinds Orion with SNMPv3.
 * `node_discover_and_add_interfaces` - Discover and add Interfaces for a SolarWinds Orion node.
 * `node_discover_and_add_interfaces_by_name_and_type` - Discover and add Interfaces for a SolarWinds Orion node based upon the ifName, ifType, and (optional) ifAdminStatus
 * `node_remanage` - Re-manage a SolarWinds Orion nodes
 * `node_status` - Query SolarWinds Orion for a node's status (i.e. Up/Down)
-* `node_unmanage` - Unmanage an SolarWinds Orion node
+* `node_unmanage` - Unmanage a SolarWinds Orion node
 * `nodes_pollnow` - Force multiple polls of a list of SolarWinds Orion nodes.
 * `query` - Execute generic SWQL queries.
 * `start_discovery` - Create a discovery profile in SolarWinds Orion.
-* `update_interface_custom_properties` - Update an the custom properties of an interface on an Orion Node
-* `update_interface_properties` - Update an the "standard" properties (e.g. Unpluggable) on an interface of an Orion Nodes 
+* `update_interface_custom_properties` - Update the custom properties of an interface on an Orion Node
+* `update_interface_properties` - Update the "standard" properties (e.g. Unpluggable) on an interface of an Orion Nodes 
 * `update_node_custom_properties` - Update an Orion Nodes custom properties
 * `update_node_poller` - Update an Orion Nodes poller
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ snmp_internal: "SNMP community to use if internal specified"
 * `list_node_custom_properties` - List the custom properties for a SolarWinds Orion nodes
 * `list_nodes_by_poller` - List the nodes on a SolarWinds Orion poller
 * `list_nodes_by_status` - List the nodes by status
-* `list_sdk_verb_args` - List all the arguments for a entity and verb that can be invoked via SolarWinds Orion.
+* `list_sdk_verb_args` - List all the arguments for an entity and verb that can be invoked via SolarWinds Orion.
 * `list_sdk_verbs` - List all the verbs that can be invoked via SolarWinds Orion
 * `ncm_config_download` - Download config(s) from SolarWinds NCM Orion module.
 * `ncm_execute_script` - Execute an script on an Orion NCM Node.

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -82,10 +82,10 @@ class AddCustomPollersToNode(OrionBaseAction):
                                      ''.format(entry))
                     # Update results data with matching poller name
                     results['existing'].append(entry)
-            else:
-                # Add Custom Poller ID to list if not found to have already been assigned to the
-                # Node
-                custompollerids.append(entrypollerid['results'][0])
+                else:
+                    # Add Custom Poller ID to list if not found to have already been assigned to the
+                    # Node
+                    custompollerids.append(entrypollerid['results'][0])
 
             # Check if the Custom poller query returned either 0 or more than the expected 1
             if len(entrypollerid['results']) > 1 or len(entrypollerid['results']) == 0:

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -62,7 +62,7 @@ class AddCustomPollersToNode(OrionBaseAction):
             entrypollerid = self.query(pollerquery)
 
             if entrypollerid:
-                custompollerids.append(entrypollerid)
+                custompollerids.append(entrypollerid['results'])
             else:
                 self.logger.info('Custom poller {} not found in Orion DB and will be '
                                  'ignored...'.format(entry))
@@ -83,7 +83,7 @@ class AddCustomPollersToNode(OrionBaseAction):
         # returned from the custom poller query on the Node
 
         for entry in custompollerids:
-            if any(element for element in nodeassignedpollers if
+            if any(element for element in nodeassignedpollers['results'] if
                    element['CustomPollerID'] == entry['CustomPollerID']):
                 self.logger.info('Custom Poller {} already assigned to Node. Skipping...'.format(
                     entry['UniqueName']))

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -83,6 +83,7 @@ class AddCustomPollersToNode(OrionBaseAction):
         # returned from the custom poller query on the Node
 
         for entry in custompollerids:
+            self.logger.info('Entry: {}'.format(entry))
             if any(element for element in nodeassignedpollers['results'] if
                    element['CustomPollerID'] == entry['CustomPollerID']):
                 self.logger.info('Custom Poller {} already assigned to Node. Skipping...'.format(
@@ -102,7 +103,7 @@ class AddCustomPollersToNode(OrionBaseAction):
                 "CustomPollerID": entry['CustomPollerID']
             }
             response = self.create('Orion.NPM.CustomPollerAssignmentOnNode', **entrydata)
-            self.logger.info('Customer poller {} successfully assigned to Node: {}'.format(
+            self.logger.info('Custom poller {} successfully assigned to Node: {}'.format(
                 entry['CustomPollerID'], response))
             # Update results data with matching poller name
             results['added'].append(entry['UniqueName'])

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -1,0 +1,65 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lib.actions import OrionBaseAction
+from lib.utils import send_user_error
+
+
+class AddSnmpPollersToNode(OrionBaseAction):
+    def run(self, node, snmppollers, custompollers):
+        """
+        Add list of SNMP Pollers to Node
+
+        Args:
+        - node: The caption in Orion of the node to poll.
+        - snmppollers: The list of Orion Pollers to add to the Node
+        - custompollers: The list of Orion Custom SNMP pollers to add to the Node
+
+        Returns
+        - List of pollers that were added to the Node and a list of Pollers that were already
+        assigned to the Node
+        - List of custom pollers that were added to the Node and a list of Custom pollers that were
+        already assigned to the Node
+
+        Raises:
+        - ValueError: When a node is not found.
+
+        """
+        # Create empty results dict to hold action output data
+        results = {snmppollers: {'added': [], 'existing': []},
+                   custompollers: {'added': [], 'existing': []}}
+
+        # Establish a connection to the Orion Server
+        self.connect()
+
+        # Find the Node in the system
+        orion_node = self.get_node(node)
+
+        if not orion_node.npm:
+            error_msg = "Node not found"
+            send_user_error(error_msg)
+            raise ValueError(error_msg)
+
+        engine_id = self.get_engine_id(poller)
+
+        kargs = {"EngineID": engine_id}
+
+        orion_data = self.update(orion_node.uri, **kargs)
+
+        # This Invoke always returns None, so check and return True
+        if orion_data is None:
+            return True
+        else:
+            return orion_data

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -97,14 +97,13 @@ class AddCustomPollersToNode(OrionBaseAction):
         # through all the entries and assign them to the Node
 
         for entry in custompollerids:
-            self.logger.info('Add Entry: {}'.format(entry))
             entrydata = {
                 "NodeID": str(orion_node.npm_id),
                 "CustomPollerID": entry['CustomPollerID']
             }
             response = self.create('Orion.NPM.CustomPollerAssignmentOnNode', **entrydata)
             self.logger.info('Custom poller {} successfully assigned to Node: {}'.format(
-                entry['CustomPollerID'], response))
+                entry['UniqueName'], response))
             # Update results data with matching poller name
             results['added'].append(entry['UniqueName'])
         return results

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -62,7 +62,7 @@ class AddCustomPollersToNode(OrionBaseAction):
             entrypollerid = self.query(pollerquery)
 
             if entrypollerid:
-                custompollerids.append(entrypollerid['results'])
+                custompollerids.append(entrypollerid['results'][0])
             else:
                 self.logger.info('Custom poller {} not found in Orion DB and will be '
                                  'ignored...'.format(entry))

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -57,7 +57,7 @@ class AddCustomPollersToNode(OrionBaseAction):
         # for the CustomPollerID.  Results will be added to the empty list created above
 
         for entry in custompollers:
-            pollerquery = 'SELECT CustomPollerID, UniqueName FROM Orion.NPM.CustomPollers where' \
+            pollerquery = 'SELECT CustomPollerID, UniqueName FROM Orion.NPM.CustomPollers where ' \
                           'UniqueName=' + str(entry)
             entrypollerid = self.query(pollerquery)
 

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -35,7 +35,7 @@ class AddCustomPollersToNode(OrionBaseAction):
 
         """
         # Create empty results dict to hold action output data
-        results = {custompollers: {'added': [], 'existing': [], 'not_found': []}}
+        results = {'added': [], 'existing': [], 'not_found': []}
 
         # Establish a connection to the Orion Server
         self.connect()

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -81,7 +81,7 @@ class AddCustomPollersToNode(OrionBaseAction):
                     self.logger.info('Custom Poller {} already assigned to Node. Skipping...'
                                      ''.format(entry))
                     # Update results data with matching poller name
-                    results['existing'].append(entry['UniqueName'])
+                    results['existing'].append(entry)
             else:
                 # Add Custom Poller ID to list if not found to have already been assigned to the
                 # Node

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -83,7 +83,7 @@ class AddCustomPollersToNode(OrionBaseAction):
         # returned from the custom poller query on the Node
 
         for entry in custompollerids:
-            self.logger.info('Entry: {}'.format(entry))
+            self.logger.info('Delete Entry: {}'.format(entry))
             if any(element for element in nodeassignedpollers['results'] if
                    element['CustomPollerID'] == entry['CustomPollerID']):
                 self.logger.info('Custom Poller {} already assigned to Node. Skipping...'.format(
@@ -97,7 +97,7 @@ class AddCustomPollersToNode(OrionBaseAction):
         # entries and assign them to the Node
 
         for entry in custompollerids:
-            self.logger.info('Entry: {}'.format(entry))
+            self.logger.info('Add Entry: {}'.format(entry))
             entrydata = {
                 "NodeID": str(orion_node.npm_id),
                 "CustomPollerID": entry['CustomPollerID']

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -96,6 +96,7 @@ class AddCustomPollersToNode(OrionBaseAction):
         # entries and assign them to the Node
 
         for entry in custompollerids:
+            self.logger.info('Entry: {}'.format(entry))
             entrydata = {
                 "NodeID": str(orion_node.npm_id),
                 "CustomPollerID": entry['CustomPollerID']

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -88,7 +88,7 @@ class AddCustomPollersToNode(OrionBaseAction):
                 custompollerids.append(entrypollerid['results'][0])
 
             # Check if the Custom poller query returned either 0 or more than the expected 1
-            if len(entrypollerid['results']) >= 1 or len(entrypollerid['results']) == 0:
+            if len(entrypollerid['results']) > 1 or len(entrypollerid['results']) == 0:
                 self.logger.info('Custom poller {} not found in Orion DB or the text query returned'
                                  ' multiple entries and will be ignored...'.format(entry))
                 results['not_found'].append(entry)

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -98,7 +98,7 @@ class AddCustomPollersToNode(OrionBaseAction):
         for entry in custompollerids:
             entrydata = {
                 "NodeID": str(orion_node.npm_id),
-                "CustomPollerID": str(entry['CustomPollerID'])
+                "CustomPollerID": entry['CustomPollerID']
             }
             response = self.create('Orion.NPM.CustomPollerAssignmentOnNode', **entrydata)
             self.logger.info('Customer poller {} successfully assigned to Node: {}'.format(

--- a/actions/add_custom_pollers_to_node.py
+++ b/actions/add_custom_pollers_to_node.py
@@ -58,7 +58,7 @@ class AddCustomPollersToNode(OrionBaseAction):
 
         for entry in custompollers:
             pollerquery = 'SELECT CustomPollerID, UniqueName FROM Orion.NPM.CustomPollers where ' \
-                          'UniqueName=' + str(entry)
+                          'UniqueName=\'' + str(entry) + '\''
             entrypollerid = self.query(pollerquery)
 
             if entrypollerid:

--- a/actions/add_custom_pollers_to_node.yaml
+++ b/actions/add_custom_pollers_to_node.yaml
@@ -11,7 +11,7 @@ parameters:
     type: "string"
     description: The Node which will have the custom pollers assigned to it
     required: true
-  custom_pollers:
+  custompollers:
     type: "array"
     description: List of custom (Universal Device) pollers to be added to Node
     required: true

--- a/actions/add_custom_pollers_to_node.yaml
+++ b/actions/add_custom_pollers_to_node.yaml
@@ -1,0 +1,17 @@
+---
+description: "Add custom NPM Universal Device Pollers to a Node in SolarWinds"
+enabled: true
+entry_point: 'add_custom_pollers_to_node.py'
+name: "add_custom_pollers_to_node"
+pack: "orion"
+runner_type: "python-script"
+
+parameters:
+  node:
+    type: "string"
+    description: The node to add the custom (Universal Device) pollers to
+    required: true
+  custom_pollers:
+    type: "array"
+    description: List of custom (Universal Device) pollers to be added to Node
+    required: true

--- a/actions/add_custom_pollers_to_node.yaml
+++ b/actions/add_custom_pollers_to_node.yaml
@@ -9,7 +9,7 @@ runner_type: "python-script"
 parameters:
   node:
     type: "string"
-    description: The node to add the custom (Universal Device) pollers to
+    description: The Node which will have the custom pollers assigned to it
     required: true
   custom_pollers:
     type: "array"

--- a/actions/node_create_snmpv3.py
+++ b/actions/node_create_snmpv3.py
@@ -29,7 +29,8 @@ class NodeCreateSNMPv3(OrionBaseAction):
             privacy_password,
             auth_protocol,
             auth_password,
-            status):
+            status,
+            additional_pollers):
         """
         Create an node in Orion.
         """
@@ -116,6 +117,12 @@ class NodeCreateSNMPv3(OrionBaseAction):
             pollers_to_add['N.Status.SNMP.Native'] = True
             pollers_to_add['N.ResponseTime.ICMP.Native'] = False
             pollers_to_add['N.ResponseTime.SNMP.Native'] = True
+
+        # Check to see if any additional pollers were passed as input
+        if additional_pollers:
+            # Enable all the pollers passed as input
+            for entry in additional_pollers:
+                pollers_to_add[entry] = True
 
         pollers = []
         for p in pollers_to_add:

--- a/actions/node_create_snmpv3.yaml
+++ b/actions/node_create_snmpv3.yaml
@@ -1,5 +1,5 @@
 ---
-description: "Create an node using SNMPv3 in Solarwinds Orion."
+description: "Create an node using SNMPv3 in SolarWinds Orion."
 enabled: true
 entry_point: 'node_create_snmpv3.py'
 name: "node_create_snmpv3"

--- a/actions/node_create_snmpv3.yaml
+++ b/actions/node_create_snmpv3.yaml
@@ -43,6 +43,8 @@ parameters:
     enum:
       - "MD5"
       - "SHA1"
+      - "SHA256"
+      - "SHA512"
     default: "SHA1"
   auth_password:
     type: "string"

--- a/actions/node_create_snmpv3.yaml
+++ b/actions/node_create_snmpv3.yaml
@@ -54,3 +54,7 @@ parameters:
       - "icmp"
     description: "Protocol to use for Status and Response Time checks."
     default: "snmp"
+  additional_pollers:
+    type: "array"
+    required: false
+    description: "List of Orion pollers to enable when creating Node. ** Must be specified using the correct Orion DB naming syntax."

--- a/actions/node_create_snmpv3.yaml
+++ b/actions/node_create_snmpv3.yaml
@@ -35,6 +35,7 @@ parameters:
   privacy_password:
     type: "string"
     required: true
+    secret: true
     description: "The SNMPv3 Privacy password used to poll SNMP from remote device."
   auth_protocol:
     type: "string"
@@ -46,6 +47,7 @@ parameters:
   auth_password:
     type: "string"
     required: true
+    secret: true
     description: "The SNMPv3 Authentication password used to poll SNMP from remote device."
   status:
     type: "string"

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
    - ncm
    - npm
    - monitoring
-version: 1.0.2
+version: 1.0.3
 python_versions:
     - "3"
 author: Encore Technologies

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
    - ncm
    - npm
    - monitoring
-version: 1.0.1
+version: 1.0.2
 python_versions:
     - "3"
 author: Encore Technologies


### PR DESCRIPTION
- Enhanced the Node_Add_SNMPv3 to allow for a list of pollers to be specified so a list of default pollers can be specified on the Node when it is added
- Added Action - Add_Custom_pollers_to_node: Takes a list of custom pollers, validates if they are  valid and/or already assigned to the node and then adds them to the node (if not already assigned)
- Updated YAML to make password secret