### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4
+
+- Updated files to work with latest CI updates
+
 ## 1.0.3
 
 - Fixed action __repr__ to return a string (satisfy pylint).

--- a/actions/get_node_software_inventory.py
+++ b/actions/get_node_software_inventory.py
@@ -43,6 +43,7 @@ class GetNodeSoftware(OrionBaseAction):
         try:
             orion_data = self.query(swql, **kargs)
         except Exception:
+            orion_data = {}
             orion_data['results'] = "empty"
 
         return orion_data

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
    - ncm
    - npm
    - monitoring
-version: 1.0.3
+version: 1.0.4
 python_versions:
     - "3"
 author: Encore Technologies

--- a/tests/test_action_query.py
+++ b/tests/test_action_query.py
@@ -39,7 +39,7 @@ class QueryTestCase(OrionBaseActionTestCase):
         action = self.get_action_instance(config=self.full_config)
 
         result = action.run(query, parameters)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
         mock_connect.assert_called_with()
         mock_query.assert_called_with(query, **parameters)


### PR DESCRIPTION
Fixed files to work with latest CI updates:

- `orion_data` referenced before assignment
- assertEquals has been deprecated since python 2.7 and replaced with assertEqual
https://pydoc-zh.readthedocs.io/en/latest/library/unittest.html#deprecated-aliases
